### PR TITLE
update qs to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ampersandjs/ampersand-sync/issues"
   },
   "dependencies": {
-    "qs": "^1.2.1",
+    "qs": "^2.2.4",
     "underscore": "~1.6.0",
     "xhr": "^1.10.0"
   },


### PR DESCRIPTION
likely this should go at the same time as #18 as a major version bump, since we're blindly serializing data as passed in by users with qs. If serialization  mechanism changed even slightly it'd potentially break stuff.
