### PR TITLE
Fixed bug where model ajaxConfig.beforeSend could be ignored

### DIFF
--- a/ampersand-sync.js
+++ b/ampersand-sync.js
@@ -87,6 +87,8 @@ module.exports = function (method, model, options) {
             if (beforeSend) return beforeSend.apply(this, arguments);
         };
         params.xhrFields = ajaxConfig.xhrFields;
+    } else {
+        params.beforeSend = ajaxConfig.beforeSend;
     }
 
     // Turn a jQuery.ajax formatted request into xhr compatible

--- a/test/index.js
+++ b/test/index.js
@@ -216,3 +216,21 @@ test('Call user provided beforeSend function.', function (t) {
     });
     t.end();
 });
+
+test('Call user provided beforeSend function from model\'s ajaxConfig when no custom xhrFields are passed', function (t) {
+    t.plan(1);
+
+    var Me = Model.extend({
+        url: '/hi',
+        ajaxConfig: {
+            beforeSend: function (xhr) {
+                t.pass();
+            }
+        }
+    });
+
+    var m = new Me();
+    var xhr = sync('create', m);
+
+    t.end();
+});


### PR DESCRIPTION
Check for `xhrFields` on the `ajaxConfig` and override for `beforeSend` were overshadowing referencing beforeSend from the `ajaxConfig` on the params object and `beforeSend` was ignored if `xhrFields` was undefined.
