### PR TITLE
Provide an 'always' callback

### DIFF
--- a/ampersand-sync.js
+++ b/ampersand-sync.js
@@ -27,7 +27,7 @@ module.exports = function (method, model, options) {
 
     // Ensure that we have a URL.
     if (!options.url) {
-        params.url = _.result(model, 'url') || urlError();
+        options.url = _.result(model, 'url') || urlError();
     }
 
     // Ensure that we have the appropriate request data.
@@ -38,8 +38,8 @@ module.exports = function (method, model, options) {
     // If passed a data param, we add it to the URL or body depending on request type
     if (options.data && type === 'GET') {
         // make sure we've got a '?'
-        params.url += _.contains(params.url, '?') ? '&' : '?';
-        params.url += qs.stringify(options.data);
+        options.url += _.contains(options.url, '?') ? '&' : '?';
+        options.url += qs.stringify(options.data);
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.

--- a/ampersand-sync.js
+++ b/ampersand-sync.js
@@ -99,6 +99,7 @@ module.exports = function (method, model, options) {
     // Make the request. The callback executes functions that are compatible
     // With jQuery.ajax's syntax.
     var request = options.xhr = options.xhrImplementation(ajaxSettings, function (err, resp, body) {
+        if (options.always) options.always(err, resp, body);
         if (err && options.error) return options.error(resp, 'error', err.message);
 
         // Parse body as JSON if a string.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ampersand-sync",
   "description": "Provides sync behavior for updating data from ampersand models and collections to the server.",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "browserify": {
     "transform": [

--- a/test/index.js
+++ b/test/index.js
@@ -52,12 +52,14 @@ test('passing data', function (t) {
     // on reads it should be part of the URL
     var xhr = sync('read', getStub(), {data: {a: 'a', one: 1}});
     t.equal(xhr.ajaxSettings.url, '/library?a=a&one=1', 'data passed to reads should be made into a query string');
-    var otherStub = getStub();
-    otherStub.url = '/library?something=hi';
-    var xhr2 = sync('read', otherStub, {data: {a: 'a', one: 1}});
-    t.equal(xhr2.ajaxSettings.url, '/library?something=hi&a=a&one=1', 'data passed to reads should be made into a query string');
+
+    var modelStub = getStub();
+    modelStub.url = '/library?something=hi';
+    var xhr2 = sync('read', modelStub, {data: {a: 'a', one: 1}});
+    t.equal(xhr2.ajaxSettings.url, '/library?something=hi&a=a&one=1', 'data passed to reads should be appended to an existing query string in the url');
+
     var xhr3 = sync('read', getStub(), {url: '/library/books', data: {a: 'a', one: 1}});
-    t.equal(xhr3.ajaxSettings.url, '/library/books?a=a&one=1', 'data passed to reads should added to query string for passed url');
+    t.equal(xhr3.ajaxSettings.url, '/library/books?a=a&one=1', 'data passed to reads should be added as a query string to overwritten url');
     t.end();
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,8 @@ test('read', function (t) {
     t.equal(xhr.ajaxSettings.type, 'GET');
     t.ok(!xhr.ajaxSettings.json);
     t.ok(!xhr.ajaxSettings.data);
+    var xhr2 = sync('read', getStub(), {url: '/library/books'});
+    t.equal(xhr2.ajaxSettings.url, '/library/books', 'passed url should overwrite model url');
     t.end();
 });
 
@@ -54,6 +56,8 @@ test('passing data', function (t) {
     otherStub.url = '/library?something=hi';
     var xhr2 = sync('read', otherStub, {data: {a: 'a', one: 1}});
     t.equal(xhr2.ajaxSettings.url, '/library?something=hi&a=a&one=1', 'data passed to reads should be made into a query string');
+    var xhr3 = sync('read', getStub(), {url: '/library/books', data: {a: 'a', one: 1}});
+    t.equal(xhr3.ajaxSettings.url, '/library/books?a=a&one=1', 'data passed to reads should added to query string for passed url');
     t.end();
 });
 


### PR DESCRIPTION
Provide a callback that can be used no matter what the outcome of the request is. This is useful for always running some code after the request finishes (e.g. hiding a "loading" indicator).