### PR TITLE
Delete `data` after transforming to query string

### DIFF
--- a/ampersand-sync.js
+++ b/ampersand-sync.js
@@ -51,6 +51,8 @@ module.exports = function (method, model, options) {
         // make sure we've got a '?'
         options.url += includes(options.url, '?') ? '&' : '?';
         options.url += qs.stringify(options.data);
+        //delete `data` so `xhr` doesn't use it as a body
+        delete options.data;
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.

--- a/test/index.js
+++ b/test/index.js
@@ -50,15 +50,21 @@ test('read', function (t) {
 
 test('passing data', function (t) {
     // on reads it should be part of the URL
-    var xhr = sync('read', getStub(), {data: {a: 'a', one: 1}});
+    
+    //create a plain object, with no prototypal inheritance, like qs@v3 does 
+    var data = Object.create(null);
+    data.a = 'a';
+    data.one = 1;
+    
+    var xhr = sync('read', getStub(), {data: data});
     t.equal(xhr.ajaxSettings.url, '/library?a=a&one=1', 'data passed to reads should be made into a query string');
 
     var modelStub = getStub();
     modelStub.url = '/library?something=hi';
-    var xhr2 = sync('read', modelStub, {data: {a: 'a', one: 1}});
+    var xhr2 = sync('read', modelStub, {data: data});
     t.equal(xhr2.ajaxSettings.url, '/library?something=hi&a=a&one=1', 'data passed to reads should be appended to an existing query string in the url');
 
-    var xhr3 = sync('read', getStub(), {url: '/library/books', data: {a: 'a', one: 1}});
+    var xhr3 = sync('read', getStub(), {url: '/library/books', data: data});
     t.equal(xhr3.ajaxSettings.url, '/library/books?a=a&one=1', 'data passed to reads should be added as a query string to overwritten url');
     t.end();
 });


### PR DESCRIPTION
For an HTTP GET request, a request `body` is not required* and redundant when a query string is used.

I'm proposing that `data` is deleted from the request options, after it has been transformed into a query string, so that it doesn't get passed along to xhr, which would normally also send that data as its body. (see https://github.com/Raynos/xhr/blob/15501698235a8b5c3151e218ad4f2f3fbda7007d/index.js#L106 and https://github.com/Raynos/xhr/blob/15501698235a8b5c3151e218ad4f2f3fbda7007d/index.js#L163 for where this happens).

This may also have the positive side-effect of sending less data, as the (useless/redundant) body isn't sent. Just a guess.

I also added tweaked the tests to use plain objects (see below) that would cause the request to fail, unless `data` was deleted from options.

Background: I discovered this when I switched to qs@v3 (in my own code) and noticed that `xhr`'s `send(body)` line would complain "Cannot convert object to primitive value". This was in part because qs@v3 had switched to plain objects (no prototypal methods), and `send(body)` would try to call `toString` (or similar) on it (which won't work on a plain object). However, I posited that for GET requests, the body shouldn't have been set anyway, since `data` was being transformed to a querystring. So, here we are.

*sending a request body also isn't supported/is ignored by many HTTP servers, because AFAIK, it's loosely defined/confusing in the spec. (see http://stackoverflow.com/a/983458)