### PR TITLE
defaulting to HTTP code message if no other message could be returned

### DIFF
--- a/core.js
+++ b/core.js
@@ -113,7 +113,7 @@ module.exports = function (xhr) {
           if (err || resp.statusCode >= 400) {
               if (options.error) {
                   var message = (err? err.message : (body || "HTTP"+resp.statusCode));
-                  return options.error(resp, 'error', message, resp);
+                  return options.error(resp, 'error', message);
               }
           } else {
               // Parse body as JSON if a string.

--- a/core.js
+++ b/core.js
@@ -111,7 +111,10 @@ module.exports = function (xhr) {
       // With jQuery.ajax's syntax.
       var request = options.xhr = options.xhrImplementation(ajaxSettings, function (err, resp, body) {
           if (err || resp.statusCode >= 400) {
-              if (options.error) return options.error(resp, 'error', (err? err.message : body));
+              if (options.error) {
+                  var message = (err? err.message : (body || "HTTP"+resp.statusCode));
+                  return options.error(resp, 'error', message, resp);
+              }
           } else {
               // Parse body as JSON if a string.
               if (body && typeof body === 'string') {

--- a/test/unit.js
+++ b/test/unit.js
@@ -211,7 +211,21 @@ test('should call provided error callback on error.', function (t) {
     });
 });
 
-test('should call provided error callback is bad JSON error.', function (t) {
+test('should call provided error callback on HTTP error.', function (t) {
+    t.plan(1);
+    var xhr = sync('read', modelStub(), {
+        error: function (resp,type,error) {
+            t.equal(error,'HTTP400');
+            t.end();
+        },
+        xhrImplementation: function (ajaxSettings, callback) {
+            callback(null, {statusCode:400}, null);
+            return {};
+        }
+    });
+});
+
+test('should call provided error callback for bad JSON.', function (t) {
     t.plan(3);
 
     var xhr = sync('read', modelStub(), {


### PR DESCRIPTION
Addresses https://github.com/AmpersandJS/ampersand-sync/pull/51 in a more lightweight way