### PR TITLE
Fire "always" callback after success / error

### DIFF
--- a/core.js
+++ b/core.js
@@ -113,7 +113,7 @@ module.exports = function (xhr) {
           if (err || resp.statusCode >= 400) {
               if (options.error) {
                   var message = (err? err.message : (body || "HTTP"+resp.statusCode));
-                  return options.error(resp, 'error', message);
+                  options.error(resp, 'error', message);
               }
           } else {
               // Parse body as JSON if a string.
@@ -121,11 +121,14 @@ module.exports = function (xhr) {
                   try {
                       body = JSON.parse(body);
                   } catch (err) {
-                      if (options.error) return options.error(resp, 'error', err.message);
+                      if (options.error) options.error(resp, 'error', err.message);
+                      if (options.always) options.always(err, resp, body);
+                      return;
                   }
               }
-              if (options.success) return options.success(body, 'success', resp);
+              if (options.success) options.success(body, 'success', resp);
           }
+          if (options.always) options.always(err, resp, body);
       });
       model.trigger('request', model, request, options, ajaxSettings);
       request.ajaxSettings = ajaxSettings;

--- a/test/unit.js
+++ b/test/unit.js
@@ -257,3 +257,34 @@ test('should not call success when error occurs and there\'s no error callback',
         }
     });
 });
+
+test('Call "always" after success callback', function (t) {
+    t.plan(1);
+
+    var xhr = sync('read', modelStub(), {
+        always: function (err, resp, body) {
+            t.equal(err, null, 'error param is null');
+            t.end();
+        },
+        xhrImplementation: function (ajaxSettings, callback) {
+            callback(null, {}, '{"good": "json"}');
+            return {};
+        }
+    });
+});
+
+test('Call "always" after error callback', function (t) {
+    t.plan(1);
+
+    var xhr = sync('read', modelStub(), {
+        always: function (err, resp, body) {
+            t.pass();
+            t.end();
+        },
+        xhrImplementation: function (ajaxSettings, callback) {
+           callback(new Error(), {}, '{"good": "json"}');
+           return {};
+        }
+    });
+});
+


### PR DESCRIPTION
Cherry picked changes from #33 onto master. @mhamann this look okay? Retained your authorship with `commit -C`

(oops mentioned the wrong person, sorry)