### PR TITLE
Make model optional

### DIFF
--- a/core.js
+++ b/core.js
@@ -132,7 +132,7 @@ module.exports = function (xhr) {
           }
           if (options.always) options.always(err, resp, body);
       });
-      model.trigger('request', model, request, options, ajaxSettings);
+      if (model) model.trigger('request', model, request, options, ajaxSettings);
       request.ajaxSettings = ajaxSettings;
       return request;
   };


### PR DESCRIPTION
`model`, while typically used, should be an optional parameter