### PR TITLE
fix #28 - putting the whole ajaxConfig in xhr settings

### DIFF
--- a/core.js
+++ b/core.js
@@ -39,16 +39,22 @@ module.exports = function (xhr) {
       
       
       var ajaxConfig = (result(model, 'ajaxConfig') || {});
-
+      var key;
       // Combine generated headers with user's headers.
       if (ajaxConfig.headers) {
-          for (var key in ajaxConfig.headers) {
+          for (key in ajaxConfig.headers) {
               headers[key.toLowerCase()] = ajaxConfig.headers[key];
           }
       }
-      ajaxConfig.headers=headers;
+      if (options.headers) {
+          for (key in options.headers) {
+              headers[key.toLowerCase()] = options.headers[key];
+          }
+          delete options.headers;
+      }
       //ajaxConfig has to be merged into params before other options take effect, so it is in fact a 2lvl default
       assign(params, ajaxConfig);
+      params.headers = headers;
 
       // Ensure that we have a URL.
       if (!options.url) {

--- a/core.js
+++ b/core.js
@@ -36,6 +36,19 @@ module.exports = function (xhr) {
 
       // Default request options.
       var params = {type: type};
+      
+      
+      var ajaxConfig = (result(model, 'ajaxConfig') || {});
+
+      // Combine generated headers with user's headers.
+      if (ajaxConfig.headers) {
+          for (var key in ajaxConfig.headers) {
+              headers[key.toLowerCase()] = ajaxConfig.headers[key];
+          }
+      }
+      ajaxConfig.headers=headers;
+      //ajaxConfig has to be merged into params before other options take effect, so it is in fact a 2lvl default
+      assign(params, ajaxConfig);
 
       // Ensure that we have a URL.
       if (!options.url) {
@@ -58,7 +71,7 @@ module.exports = function (xhr) {
 
       // For older servers, emulate JSON by encoding the request into an HTML-form.
       if (options.emulateJSON) {
-          headers['content-type'] = 'application/x-www-form-urlencoded';
+          params.headers['content-type'] = 'application/x-www-form-urlencoded';
           params.body = params.json ? {model: params.json} : {};
           delete params.json;
       }
@@ -68,7 +81,7 @@ module.exports = function (xhr) {
       if (options.emulateHTTP && (type === 'PUT' || type === 'DELETE' || type === 'PATCH')) {
           params.type = 'POST';
           if (options.emulateJSON) params.body._method = type;
-          headers['x-http-method-override'] = type;
+          params.headers['x-http-method-override'] = type;
       }
 
       // When emulating JSON, we turn the body into a querystring.
@@ -77,24 +90,7 @@ module.exports = function (xhr) {
           params.body = qs.stringify(params.body);
       }
 
-      // Start setting ajaxConfig options (headers, xhrFields).
-      var ajaxConfig = (result(model, 'ajaxConfig') || {});
-
-      // Combine generated headers with user's headers.
-      if (ajaxConfig.headers) {
-          for (var key in ajaxConfig.headers) {
-              headers[key.toLowerCase()] = ajaxConfig.headers[key];
-          }
-      }
-      
-      params.headers = headers;
-
-      //Set XDR for cross domain in IE8/9
-      if (ajaxConfig.useXDR ) {
-          params.useXDR = true;
-      }
-
-      // Set raw xhr options.
+      // Set raw XMLHttpRequest options.
       if (ajaxConfig.xhrFields) {
           var beforeSend = ajaxConfig.beforeSend;
           params.beforeSend = function (req) {
@@ -102,9 +98,7 @@ module.exports = function (xhr) {
               if (beforeSend) return beforeSend.apply(this, arguments);
           };
           params.xhrFields = ajaxConfig.xhrFields;
-      } else {
-          params.beforeSend = ajaxConfig.beforeSend;
-      }
+      } 
 
       // Turn a jQuery.ajax formatted request into xhr compatible
       params.method = params.type;
@@ -121,7 +115,7 @@ module.exports = function (xhr) {
               }
           } else {
               // Parse body as JSON
-              if (typeof body === 'string' && (!headers.accept || headers.accept.indexOf('application/json')===0)) {
+              if (typeof body === 'string' && (!params.headers.accept || params.headers.accept.indexOf('application/json')===0)) {
                   try {
                       body = JSON.parse(body);
                   } catch (err) {

--- a/test/unit.js
+++ b/test/unit.js
@@ -34,6 +34,32 @@ test('should allow models to overwrite ajax configs at the model level', functio
     var xhr = sync('read', m);
 });
 
+test('should merge headers and lowercase them', function (t) {
+    t.plan(3);
+    var Me = Model.extend({
+        url: '/hi',
+        ajaxConfig: {
+            headers: {
+                ACcept: 'application/xml',
+                "X-Other-Header": "ok"
+            }
+        }
+    });
+    var m = new Me();
+    m.on('request', function (model, xhr, options, ajaxSettings) {
+        t.equal(reqStub.recentOpts.headers.accept, '*/*');
+        t.equal(reqStub.recentOpts.headers["x-other-header"], 'ok');
+        t.equal(reqStub.recentOpts.headers["x-another-header"], 'ok');
+        t.end();
+    });
+    var xhr = sync('read', m, {
+        headers: {
+            accEPT: '*/*',
+            "X-anOther-Header": "ok"
+        }
+    });
+});
+
 test('read', function (t) {
     sync('read', modelStub());
     t.equal(reqStub.recentOpts.url, '/library');


### PR DESCRIPTION
I had to change the order of things being applied to make it reasonable.

I still don't like how `options` get merged in - you can override the whole headers definition with options, bypassing the lowercasing loop etc.
See: https://github.com/AmpersandJS/ampersand-sync/pull/64/files#diff-04aff9558c8839f145fd5cc256639700R106
It's a breaking change, but I think I'll have to make it work.