### PR TITLE
fix #52 parse json in error responses if possible

### DIFF
--- a/core.js
+++ b/core.js
@@ -116,6 +116,9 @@ module.exports = function (xhr) {
       var request = options.xhr = options.xhrImplementation(ajaxSettings, function (err, resp, body) {
           if (err || resp.statusCode >= 400) {
               if (options.error) {
+                  try {
+                      body = JSON.parse(body);
+                  } catch(e){}
                   var message = (err? err.message : (body || "HTTP"+resp.statusCode));
                   options.error(resp, 'error', message);
               }

--- a/test/unit.js
+++ b/test/unit.js
@@ -249,6 +249,21 @@ test('should call provided error callback on HTTP error.', function (t) {
     });
 });
 
+
+test('should parse JSON in error responses if possible', function (t) {
+    t.plan(1);
+    var xhr = sync('read', modelStub(), {
+        error: function (resp,type,error) {
+            t.equal(error.e,"rror");
+            t.end();
+        },
+        xhrImplementation: function (ajaxSettings, callback) {
+            callback(null, {statusCode:400}, '{"e":"rror"}');
+            return {};
+        }
+    });
+});
+
 test('should call provided error callback for bad JSON.', function (t) {
     t.plan(2);
 


### PR DESCRIPTION
Could somebody related with ampersand-model comment about this? I'd rather not merge it if there's an assumption that the error response must be a string. It's not a vast improvement for usability and if something would require refactoring just because of that, let's drop this PR altogether.
