### PR TITLE
parse response as json if accept subtype or suffix is json

### DIFF
--- a/core.js
+++ b/core.js
@@ -4,6 +4,7 @@ var defaults = require('lodash.defaults');
 var includes = require('lodash.includes');
 var assign = require('lodash.assign');
 var qs = require('qs');
+var mediaType = require('media-type');
 
 
 module.exports = function (xhr) {
@@ -127,7 +128,9 @@ module.exports = function (xhr) {
               }
           } else {
               // Parse body as JSON
-              if (typeof body === 'string' && (!params.headers.accept || params.headers.accept.indexOf('application/json')===0)) {
+              var accept = mediaType.fromString(params.headers.accept);
+              var parseJson = accept.isValid() && accept.type === 'application' && (accept.subtype === 'json' || accept.suffix === 'json');
+              if (typeof body === 'string' && (!params.headers.accept || parseJson)) {
                   try {
                       body = JSON.parse(body);
                   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash.defaults": "^3.1.0",
     "lodash.includes": "^3.1.0",
     "lodash.result": "^3.0.0",
-    "media-type": "^0.3.0",
+    "media-type": "0.3.0",
     "qs": "^4.0.0",
     "request": "^2.55.0",
     "xhr": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lodash.defaults": "^3.1.0",
     "lodash.includes": "^3.1.0",
     "lodash.result": "^3.0.0",
+    "media-type": "^0.3.0",
     "qs": "^4.0.0",
     "request": "^2.55.0",
     "xhr": "^2.0.3"

--- a/test/unit.js
+++ b/test/unit.js
@@ -326,3 +326,29 @@ test('Call "always" after error callback', function (t) {
     });
 });
 
+test('should parse json for different media types', function (t) {
+    t.plan(4);
+
+    var jsonMediaTypes = [
+        '', // Test with no accept header
+        'application/hal+json',
+        'application/json+hal',
+        'application/json'
+    ];
+
+    jsonMediaTypes.forEach(function (mediaType) {
+        sync('read', modelStub(), {
+            headers: {
+                accept: 'application/hal+json'
+            },
+            success: function (resp, type, error) {
+                t.deepEqual(resp.good, 'json', (mediaType || 'no type') + ' is parsed as json');
+            },
+            xhrImplementation: function (ajaxSettings, callback) {
+                callback(null, {}, '{"good": "json"}');
+                return {};
+            }
+        });
+    });
+});
+


### PR DESCRIPTION
I have an app that uses `accept: 'application/hal+json'` which I think should be parsed as JSON as well.

Used [`media-type`](https://www.npmjs.com/package/media-type) for the parsing.