### PR TITLE
Allow the HTTP method to be provided directly 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var sync = require("ampersand-sync")
 var rawRequest = sync(method, model, options)
 ```
 
-**method** is a string used for choosing HTTP verb of the sync request. It has to be chosen from the keys of the following map:
+**method** is a string used for choosing HTTP verb of the sync request. You can either provide the HTTP method you want to use directly (GET, POST, etc) or specify a RESTful operation which will apply the following convention (used by `ampersand-model`):
 ```js
 {
       'create': 'POST',

--- a/core.js
+++ b/core.js
@@ -27,7 +27,7 @@ module.exports = function (xhr) {
       //Copy the options object. It's using assign instead of clonedeep as an optimization. 
       //The only object we could expect in options is headers, which is safely transfered below.
       var options = assign({},optionsInput);
-      var type = methodMap[method];
+      var type = methodMap[method] || method;
       var headers = {};
 
       // Default options, unless specified.

--- a/core.js
+++ b/core.js
@@ -66,7 +66,7 @@ module.exports = function (xhr) {
       }
 
       // Ensure that we have the appropriate request data.
-      if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
+      if (options.data == null && model && (type === 'POST' || type === 'PUT' || type === 'PATCH')) {
           params.json = options.attrs || model.toJSON(options);
       }
 


### PR DESCRIPTION
This PR will allow the callee of ampersand-sync to provide the HTTP method to use in the call directly  (instead of forcing you to pass the model's intention).

In REST systems, the need to call custom endpoints is a common one (Eg, sending a POST request to some ...api/:id/refresh, that has side-effects). In order to accommodate for this, a good approach would be to implement a custom method on the model, or a more generic approach like this one: https://gist.github.com/ruiramos/1687be7a7edaa14816ec

This PR intends to remove the need for that unMapMethod map and make ampersand-sync a bit more generic and less dependent on model lingo.