### PR TITLE
Update dependency: xhr

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "media-type": "0.3.0",
     "qs": "^4.0.0",
     "request": "^2.55.0",
-    "xhr": "^2.0.4"
+    "xhr": "^2.0.5"
   },
   "devDependencies": {
     "ampersand-model": "^5.0.3",


### PR DESCRIPTION
This version of xhr now passes `null` instead of `undefined` as a default body value to the `send` method of an instance of XMLHttpRequest. In most browsers, `undefined` had no ill-consequences when making a request, but as I discovered, Microsoft Edge was including `undefined` as the body of the request, which some servers don't like. `null` is a long-accepted way of indicating there is no body after the headers are sent.

See Raynos/xhr#100 for more.