### PR TITLE
xhr@v2.3 compliance

### DIFF
--- a/core.js
+++ b/core.js
@@ -67,7 +67,8 @@ module.exports = function (xhr) {
 
       // Ensure that we have the appropriate request data.
       if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
-          params.json = options.attrs || model.toJSON(options);
+          params.body = options.attrs || model.toJSON(options);
+          params.json = true;
       }
 
       // If passed a data param, we add it to the URL or body depending on request type
@@ -82,7 +83,7 @@ module.exports = function (xhr) {
       // For older servers, emulate JSON by encoding the request into an HTML-form.
       if (options.emulateJSON) {
           params.headers['content-type'] = 'application/x-www-form-urlencoded';
-          params.body = params.json ? {model: params.json} : {};
+          params.body = params.json ? {model: params.body || params.json} : {};
           delete params.json;
       }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "media-type": "0.3.0",
     "qs": "^6.1.0",
     "request": "^2.55.0",
-    "xhr": "^2.0.5"
+    "xhr": "^2.3.1"
   },
   "devDependencies": {
     "ampersand-model": "^7.0.0",

--- a/test/unit.js
+++ b/test/unit.js
@@ -115,7 +115,7 @@ test('create', function (t) {
     }));
     t.equal(reqStub.recentOpts.url, '/library');
     t.equal(reqStub.recentOpts.method, 'POST');
-    t.ok(reqStub.recentOpts.json, 'body passed as json');
+    t.equal(reqStub.recentOpts.json, true, 'json is set to true');
     var data = reqStub.recentOpts.body;
     t.equal(data.title, 'The Tempest');
     t.equal(data.author, 'Bill Shakespeare');
@@ -130,7 +130,7 @@ test('update', function (t) {
     }));
     t.equal(reqStub.recentOpts.url, '/library');
     t.equal(reqStub.recentOpts.method, 'PUT');
-    t.ok(reqStub.recentOpts.json, 'body passed as json');
+    t.equal(reqStub.recentOpts.json, true, 'json is set to true');
     var data = reqStub.recentOpts.body;
     t.equal(data.id, '1-the-tempest');
     t.equal(data.author, 'William Shakespeare');
@@ -163,7 +163,7 @@ test('update with just emulateHTTP', function (t) {
     });
     t.equal(reqStub.recentOpts.url, '/library');
     t.equal(reqStub.recentOpts.method, 'POST');
-    t.ok(reqStub.recentOpts.json, 'body passed as json');
+    t.equal(reqStub.recentOpts.json, true, 'json is set to true');
     var data = reqStub.recentOpts.body;
     t.equal(data.id, '2-the-tempest');
     t.equal(data.author, 'Tim Shakespeare');

--- a/test/unit.js
+++ b/test/unit.js
@@ -116,7 +116,7 @@ test('create', function (t) {
     t.equal(reqStub.recentOpts.url, '/library');
     t.equal(reqStub.recentOpts.method, 'POST');
     t.ok(reqStub.recentOpts.json, 'body passed as json');
-    var data = reqStub.recentOpts.json;
+    var data = reqStub.recentOpts.body;
     t.equal(data.title, 'The Tempest');
     t.equal(data.author, 'Bill Shakespeare');
     t.equal(data.length, 123);
@@ -131,7 +131,7 @@ test('update', function (t) {
     t.equal(reqStub.recentOpts.url, '/library');
     t.equal(reqStub.recentOpts.method, 'PUT');
     t.ok(reqStub.recentOpts.json, 'body passed as json');
-    var data = reqStub.recentOpts.json;
+    var data = reqStub.recentOpts.body;
     t.equal(data.id, '1-the-tempest');
     t.equal(data.author, 'William Shakespeare');
     t.end();
@@ -164,7 +164,7 @@ test('update with just emulateHTTP', function (t) {
     t.equal(reqStub.recentOpts.url, '/library');
     t.equal(reqStub.recentOpts.method, 'POST');
     t.ok(reqStub.recentOpts.json, 'body passed as json');
-    var data = reqStub.recentOpts.json;
+    var data = reqStub.recentOpts.body;
     t.equal(data.id, '2-the-tempest');
     t.equal(data.author, 'Tim Shakespeare');
     t.equal(data.length, 123);

--- a/test/unit.js
+++ b/test/unit.js
@@ -352,3 +352,21 @@ test('should parse json for different media types', function (t) {
     });
 });
 
+test('passing `body` in the opts should take precedence over the model\'s data', function (t) {
+	var model = modelStub({
+        title: 'The Tempest',
+        author: 'Bill Shakespeare',
+        length: 123
+    });
+
+    sync('create', model, {
+	    body: {
+		    rating: "5"
+	    }
+    });
+
+    t.equal(reqStub.recentOpts.json, true, 'json is set to true');
+    var data = reqStub.recentOpts.body;
+    t.equal(data.rating, '5');
+    t.end();
+});


### PR DESCRIPTION
Recently, xhr clarified its behaviour for the `json` option, suggesting that `json` is flipped on/off, and the `body` is instead set to… the body. This has the side effect of preventing true/false being sent as a value via the `json` option, but is otherwise backwards compatible.

This PR is mostly to bring ampersand-sync inline with how xhr prefers its data, but also solves one very specific, confusing use case that would fail (without this PR). I'll try to explain it:

```js
//get an ampersand-model somehow…
// and then proceed to create a custom request using `sync` (with a custom `body`),
// which basically proxies the options to xhr

const opts = {
    body: {foo: "bar"},
    json: true
};

model.sync("create", model, opts);

//what currently happens is ampersand-sync will set the `json` option 
// to the model's data (`model.toJSON()`), which will
// prevent `opts.body` from being used in `xhr`, as `json` is contain's the model's data, and since it's not a boolean, it takes precedence over `body`

//with this PR, ampersand-sync will now set `params.body` to the model's data.
// However, when it comes time to invoke `xhr`, `ajaxSettings` is built up of `params` and `options` (with the values in `options` taking precedence via `assign`).
// so, in the end the `body` property of `ajaxSettings` –which is what `xhr`will use in `send()`– is equal to `opts.body` (which is arguably what we want) and not the value from `model.toJSON()`

```

In short, this should make `.sync` options behaviour more congruent with xhr's options behaviour. While using `body` is not an option specified within ampersand-sync's documentation, and `data` should probably be used to pass data, sometimes it's tricky to remember which property to use (body or data) when switching between `xhr` and `ampersand-sync`.

Overall, this PR shouldn't introduce any breaking changes.