### PR TITLE
Use the last argument of lodash.result for the ajaxConfig fallback value

### DIFF
--- a/core.js
+++ b/core.js
@@ -41,8 +41,7 @@ module.exports = function (xhr) {
       // Default request options.
       var params = {type: type};
 
-
-      var ajaxConfig = (result(model, 'ajaxConfig') || {});
+      var ajaxConfig = result(model, 'ajaxConfig', {});
       var key;
       // Combine generated headers with user's headers.
       if (ajaxConfig.headers) {


### PR DESCRIPTION
lodash's result method takes a third argument which is a fallback value to use in case model.ajaxConfig doesn't resolve.

Also remove extra line break