### PR TITLE
Fix failure on 204 in the node environment

### DIFF
--- a/core.js
+++ b/core.js
@@ -129,7 +129,7 @@ module.exports = function (xhr) {
               // Parse body as JSON
               var accept = mediaType.fromString(params.headers.accept);
               var parseJson = accept.isValid() && accept.type === 'application' && (accept.subtype === 'json' || accept.suffix === 'json');
-              if (typeof body === 'string' && (!params.headers.accept || parseJson)) {
+              if (typeof body === 'string' && body !== '' && (!params.headers.accept || parseJson)) {
                   try {
                       body = JSON.parse(body);
                   } catch (err) {


### PR DESCRIPTION
Hi,

The problem we were experiencing is that we have an endpoint that returns a 204. With request in the browser, the body is null, however in Node (server-side rendering) the body is an empty string. This causes the JSON parse to fail and the promise to reject only on server-side rendering.

Now, this could potentially be solved by submitting a PR to `request` to fix this behavior, but for such a big library it's hard to say if this behavior is intended or not, and that change could have sweeping consequences. So it's probably unlikely that we could change that behavior.