### PR TITLE
Set qs.stringify encoding options to create a different query string for array values

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Additional fields in `options`:
  - emulateJSON - defaults to `false`
  - xhrImplementation - can be used to override http request implementation for just this one call
  - data - JSON serializable object to be sent as request body
+ - qsOptions - set stringify encoding options and create a different URI output if needed [[see qs.stringify(string,[options])]](https://www.npmjs.com/package/qs/v/4.0.0#stringifying)
  - `success(body, 'success', responseObject)` - optional callback to be called when request finishes successfully
  - `error(responseObject, 'error', error.message)` - optional callback to be called when an error occurs (http request/response error or parsing response error)
  - `always(error, responseObject, body)` - optional callback to be called when request finishes no matter what the result

--- a/core.js
+++ b/core.js
@@ -73,14 +73,10 @@ module.exports = function (xhr) {
       if (options.data && type === 'GET') {
           // make sure we've got a '?'
           options.url += includes(options.url, '?') ? '&' : '?';
-          // set stringify encoding options and create a different URI output if needed
+          // set stringify encoding options and create a different URI output if qsOption is defined
           // ex) qsOptions = { indices: false }
           // https://www.npmjs.com/package/qs/v/4.0.0#stringifying
-          if(options.qsOptions){
-            options.url += qs.stringify(options.data, options.qsOptions);
-          }else{
-            options.url += qs.stringify(options.data);
-          }
+          options.url += qs.stringify(options.data, options.qsOptions);
           
           //delete `data` so `xhr` doesn't use it as a body
           delete options.data;

--- a/core.js
+++ b/core.js
@@ -73,7 +73,15 @@ module.exports = function (xhr) {
       if (options.data && type === 'GET') {
           // make sure we've got a '?'
           options.url += includes(options.url, '?') ? '&' : '?';
-          options.url += qs.stringify(options.data);
+          // set stringify encoding options and create a different URI output if needed
+          // ex) qsOptions = { indices: false }
+          // https://www.npmjs.com/package/qs/v/4.0.0#stringifying
+          if(options.qsOptions){
+            options.url += qs.stringify(options.data, options.qsOptions);
+          }else{
+            options.url += qs.stringify(options.data);
+          }
+          
           //delete `data` so `xhr` doesn't use it as a body
           delete options.data;
       }

--- a/test/unit.js
+++ b/test/unit.js
@@ -99,10 +99,25 @@ test('passing data', function (t) {
         url: '/library/books',
         data: {
             a: 'a',
-            one: 1
+            one: 1,
+            status: ["one", "two"]
         }
     });
-    t.equal(reqStub.recentOpts.url, '/library/books?a=a&one=1', 'data passed to reads should be added as a query string to overwritten url');
+    t.equal(reqStub.recentOpts.url, '/library/books?a=a&one=1&status%5B0%5D=one&status%5B1%5D=two', 'data passed to reads should be added as a query string to overwritten url');
+    t.equal(typeof reqStub.recentOpts.data, 'undefined', 'data leftovers should be cleaned up');
+
+    sync('read', modelStub(), {
+        url: '/library/books',
+        data: {
+            a: 'a',
+            one: 1,
+            status: ["one", "two"]
+        },
+        qsOptions: {
+            indices: false
+        }
+    });
+    t.equal(reqStub.recentOpts.url, '/library/books?a=a&one=1&status=one&status=two', 'data passed to reads should be added as a query string to overwritten url with qsOptions overwriting qs.stringify default behavior');
     t.equal(typeof reqStub.recentOpts.data, 'undefined', 'data leftovers should be cleaned up');
     t.end();
 });


### PR DESCRIPTION
If we send a data prop to the fetch call in `ampersand-model` or `ampersand-rest-collection` the qs.stringify function encodes the data and updates the options.url string but if we send a data object that has an array prop the encoding will keep the index of the array in the URL string.

But we can overwrite the default behavior of the qs.stringify function by setting options.

```javascript
var data = {
a:"a",
b:1,
c:["one", "two"]
}

qs.stringify(data);
//outputs => a=a&one=1&status%5B0%5D=one&status%5B1%5D=two

qs.stringify(data, { indices: false });
//outputs => a=a&one=1&status=one&status=two

```

